### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/LinuxUserGD/butler/security/code-scanning/1](https://github.com/LinuxUserGD/butler/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient, as the workflow only reads repository contents and does not perform any write operations. The `permissions` block will be added at the root level of the workflow, applying to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
